### PR TITLE
Feature/add to cart session storage

### DIFF
--- a/client/Components/App/App.jsx
+++ b/client/Components/App/App.jsx
@@ -5,9 +5,14 @@ import Header from '../Header/Header';
 import Cart from '../Cart/Cart';
 import Dogs from '../Dogs/Dogs';
 import Dog from '../Dog/Dog';
-import { getBreeds, getDogs, getUser } from '../../store/actions/actions';
+import {
+  getBreeds,
+  getDogs,
+  getUser,
+  getCrate
+} from '../../store/actions/actions';
 import { ROUTE_PATH } from '../../commons/constants';
-import './app.scss'
+import './app.scss';
 
 const { DOGS, CART } = ROUTE_PATH;
 
@@ -16,6 +21,7 @@ class App extends Component {
     this.props.getBreeds();
     this.props.getDogs();
     this.props.getUser();
+    this.props.getCrate();
   }
   render() {
     return (
@@ -36,7 +42,8 @@ class App extends Component {
 const mapDispatchToProps = {
   getBreeds,
   getDogs,
-  getUser
+  getUser,
+  getCrate
 };
 
 export default connect(

--- a/client/Components/Cart/Cart.jsx
+++ b/client/Components/Cart/Cart.jsx
@@ -3,27 +3,28 @@ import { connect } from 'react-redux';
 import priceTag from '../../assets/img/icon-price-tag.svg';
 import './cart.scss';
 
-const Cart = ({ orderItems }) => {
-    return (
-        <div id="cart-container">
-            {
-                orderItems.length ?
-                    <>
-                        <h1>Here are your orders.</h1>
-                    </> :
-                    <>
-                        <h1>Don't see your items? Sign in.</h1>
-                        <h6>There are no items in your create.</h6>
-                    </>
-            }
-        </div>
-    )
-}
+const Cart = ({ crate }) => {
+  console.log('crate', crate);
+  return (
+    <div id="cart-container">
+      {crate.length ? (
+        <>
+          <h1>Here are your orders.</h1>
+        </>
+      ) : (
+        <>
+          <h1>Don't see your items? Sign in.</h1>
+          <h6>There are no items in your create.</h6>
+        </>
+      )}
+    </div>
+  );
+};
 
-const mapStateToProps = () => {
-    return {
-        orderItems: []
-    }
-}
+const mapStateToProps = ({ crate }) => {
+  return {
+    crate
+  };
+};
 
 export default connect(mapStateToProps)(Cart);

--- a/client/Components/Dog/Dog.jsx
+++ b/client/Components/Dog/Dog.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import priceTag from '../../assets/img/icon-price-tag.svg'
-import './dog.scss'
 
-const Dog = ({ dog }) => {
+import { addToCrate } from '../../store/actions/actions';
+import priceTag from '../../assets/img/icon-price-tag.svg';
+import './dog.scss';
+
+const Dog = ({ dog, addToCrate }) => {
   return dog ? (
     <div id="dog-container">
       <div id="dog-images">
@@ -34,11 +36,15 @@ const Dog = ({ dog }) => {
           <img src={priceTag} />
           <span>${dog.price}</span>
         </div>
-        <button className="btn-add-crate">Add {dog.name} to crate!</button>
+        <button className="btn-add-crate" onClick={() => addToCrate(dog.id)}>
+          Add {dog.name} to crate!
+        </button>
       </div>
     </div>
-  ) : <></>
-}
+  ) : (
+    <></>
+  );
+};
 
 const mapStateToProps = ({ dogs }, { match }) => {
   const id = match.params.id;
@@ -47,4 +53,11 @@ const mapStateToProps = ({ dogs }, { match }) => {
   };
 };
 
-export default connect(mapStateToProps)(Dog);
+const mapDispatchToProps = {
+  addToCrate
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(Dog);

--- a/client/commons/constants.js
+++ b/client/commons/constants.js
@@ -2,7 +2,8 @@ export const ACTION_TYPE = {
   SET_BREEDS: 'SET_BREEDS',
   SET_DOGS: 'SET_DOGS',
   SET_USER: 'SET_USER',
-  ADD_TO_CRATE: 'ADD_TO_CRATE'
+  ADD_TO_CRATE: 'ADD_TO_CRATE',
+  SET_CRATE: 'SET_CRATE'
 };
 
 const USER = 'user';

--- a/client/commons/constants.js
+++ b/client/commons/constants.js
@@ -1,7 +1,8 @@
 export const ACTION_TYPE = {
   SET_BREEDS: 'SET_BREEDS',
   SET_DOGS: 'SET_DOGS',
-  SET_USER: 'SET_USER'
+  SET_USER: 'SET_USER',
+  ADD_TO_CRATE: 'ADD_TO_CRATE'
 };
 
 const USER = 'user';

--- a/client/store/actions/actions.js
+++ b/client/store/actions/actions.js
@@ -1,5 +1,6 @@
 import { getBreeds } from './breedActions';
 import { getDogs } from './dogActions';
 import { getUser } from './userActions';
+import { addToCrate } from './crateActions';
 
-export { getBreeds, getDogs, getUser };
+export { getBreeds, getDogs, getUser, addToCrate };

--- a/client/store/actions/actions.js
+++ b/client/store/actions/actions.js
@@ -1,6 +1,6 @@
 import { getBreeds } from './breedActions';
 import { getDogs } from './dogActions';
 import { getUser } from './userActions';
-import { addToCrate } from './crateActions';
+import { addToCrate, getCrate } from './crateActions';
 
-export { getBreeds, getDogs, getUser, addToCrate };
+export { getBreeds, getDogs, getUser, addToCrate, getCrate };

--- a/client/store/actions/crateActions.js
+++ b/client/store/actions/crateActions.js
@@ -1,0 +1,29 @@
+import { ACTION_TYPE } from '../../commons/constants';
+
+const { ADD_TO_CRATE } = ACTION_TYPE;
+
+const getCrateFromStorage = () => {
+  const crate = sessionStorage.getItem('crate');
+  return crate ? JSON.parse(crate) : [];
+};
+
+const addToCrateFromStorage = dogId => {
+  const crate = getCrateFromStorage();
+  sessionStorage.setItem('crate', JSON.stringify([...crate, dogId]));
+};
+
+const addToCratetAction = dogId => {
+  return {
+    type: ADD_TO_CRATE,
+    dogId
+  };
+};
+
+const addToCrate = dogId => {
+  return async dispatch => {
+    addToCrateFromStorage(dogId);
+    return dispatch(addToCratetAction(dogId));
+  };
+};
+
+export { addToCrate };

--- a/client/store/actions/crateActions.js
+++ b/client/store/actions/crateActions.js
@@ -1,6 +1,6 @@
 import { ACTION_TYPE } from '../../commons/constants';
 
-const { ADD_TO_CRATE } = ACTION_TYPE;
+const { ADD_TO_CRATE, SET_CRATE } = ACTION_TYPE;
 
 const getCrateFromStorage = () => {
   const crate = sessionStorage.getItem('crate');
@@ -19,6 +19,13 @@ const addToCratetAction = dogId => {
   };
 };
 
+const setCratetAction = crate => {
+  return {
+    type: SET_CRATE,
+    crate
+  };
+};
+
 const addToCrate = dogId => {
   return async dispatch => {
     addToCrateFromStorage(dogId);
@@ -26,4 +33,11 @@ const addToCrate = dogId => {
   };
 };
 
-export { addToCrate };
+const getCrate = () => {
+  return async dispatch => {
+    const crate = getCrateFromStorage();
+    return dispatch(setCratetAction(crate));
+  };
+};
+
+export { addToCrate, getCrate };

--- a/client/store/reducers/crateReducer.js
+++ b/client/store/reducers/crateReducer.js
@@ -1,11 +1,13 @@
 import { ACTION_TYPE } from '../../commons/constants';
 
-const { ADD_TO_CRATE } = ACTION_TYPE;
+const { ADD_TO_CRATE, SET_CRATE } = ACTION_TYPE;
 
 const createReducer = (state = [], action) => {
   switch (action.type) {
     case ADD_TO_CRATE:
       return [...state, action.dogId];
+    case SET_CRATE:
+      return action.crate;
     default:
       return state;
   }

--- a/client/store/reducers/crateReducer.js
+++ b/client/store/reducers/crateReducer.js
@@ -1,0 +1,14 @@
+import { ACTION_TYPE } from '../../commons/constants';
+
+const { ADD_TO_CRATE } = ACTION_TYPE;
+
+const createReducer = (state = [], action) => {
+  switch (action.type) {
+    case ADD_TO_CRATE:
+      return [...state, action.dogId];
+    default:
+      return state;
+  }
+};
+
+export default createReducer;

--- a/client/store/reducers/reducers.js
+++ b/client/store/reducers/reducers.js
@@ -2,11 +2,13 @@ import { combineReducers } from 'redux';
 import breedReducer from './breedReducer';
 import dogReducer from './dogReducer';
 import userReducer from './userReducer';
+import crateReducer from './crateReducer';
 
 const reducer = combineReducers({
   user: userReducer,
   breeds: breedReducer,
-  dogs: dogReducer
+  dogs: dogReducer,
+  crate: crateReducer
 });
 
 export default reducer;


### PR DESCRIPTION
This PR connects the 'Add to Crate' button to a crate item in sessionStorage.

__NOTES__:
1. although we can directly access sessionStorage, I followed the action/reducer format. But i'm not sure yet if this will save us anything when we start implementing cart using the Order model for logged in users.
2. currently does not handle duplicates, i was going to put that handling, but i realized that Dog/Dog List view should show 'Remove from Crate' or disable/hide 'Add to Crate' button if it's already in the crate.

Looking for early feedback before I continue with 'Remove from Crate'