### PR TITLE
Feature/orders post endpoint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:7.10
+      - image: circleci/node:10.16.0
       - image: circleci/postgres:9.6-alpine
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/server/api/orders.js
+++ b/server/api/orders.js
@@ -1,0 +1,18 @@
+const router = require('express').Router();
+
+const db = require('./../db/db');
+const { createOrder } = db.transactions;
+const { Order, OrderItem } = db.models;
+
+router.post('/', async (req, res, next) => {
+  createOrder(req.body)
+    .then(orderId =>
+      Order.findByPk(orderId, {
+        include: [{ model: OrderItem }]
+      })
+    )
+    .then(order => res.status(201).send(order))
+    .catch(next);
+});
+
+module.exports = router;

--- a/server/api/orders.spec.js
+++ b/server/api/orders.spec.js
@@ -46,7 +46,7 @@ describe('Order routes', () => {
         .then(response => {
           const createdOrder = response.body;
           expect(createdOrder.status).to.equal('created');
-          expect(createdOrder.order_items.length).to.equal(2);
+          expect(createdOrder.orderItems.length).to.equal(2);
         });
     });
 

--- a/server/api/orders.spec.js
+++ b/server/api/orders.spec.js
@@ -31,8 +31,8 @@ describe('Order routes', () => {
       breedId: goldenDoodle.id
     };
 
-    const katsu1 = await Dog.create({ ...katsu, id: uuid.v4() });
-    const katsu2 = await Dog.create({ ...katsu, id: uuid.v4() });
+    const katsu1 = await Dog.create({ id: uuid.v4(), ...katsu });
+    const katsu2 = await Dog.create({ id: uuid.v4(), ...katsu });
 
     crate = [katsu1.id, katsu2.id];
   });

--- a/server/api/orders.spec.js
+++ b/server/api/orders.spec.js
@@ -1,0 +1,63 @@
+const uuid = require('uuid');
+const { expect } = require('chai');
+const request = require('supertest');
+const app = request(require('./../app'));
+
+const db = require('./../db/db');
+const { Breed, Dog } = db.models;
+
+describe('Order routes', () => {
+  let order;
+  let crate;
+
+  beforeEach(async () => {
+    order = {
+      email: 'katsu@goldendoodle.com',
+      street: '47 Dog Street',
+      city: 'Brooklyn',
+      state: 'NY',
+      zip: '11201',
+      country: 'USA'
+    };
+
+    const goldenDoodle = await Breed.create({ name: 'Golden Doodle' });
+    const katsu = {
+      name: 'Katsu',
+      price: 5000,
+      age: 1,
+      ageUnit: 'month',
+      gender: 'F',
+      size: 'M',
+      breedId: goldenDoodle.id
+    };
+
+    const katsu1 = await Dog.create({ ...katsu, id: uuid.v4() });
+    const katsu2 = await Dog.create({ ...katsu, id: uuid.v4() });
+
+    crate = [katsu1.id, katsu2.id];
+  });
+
+  describe('POST /api/orders', () => {
+    it('should return created order with associated order items', () => {
+      return app
+        .post('/api/orders')
+        .send({ order, crate })
+        .expect(201)
+        .then(response => {
+          const createdOrder = response.body;
+          expect(createdOrder.status).to.equal('created');
+          expect(createdOrder.order_items.length).to.equal(2);
+        });
+    });
+
+    it('should update ordered dog to unavailable', () => {});
+
+    describe('when order was not created', () => {
+      it('should not create order items', () => {});
+    });
+
+    describe('when there is a logged in user', () => {
+      it('should associate the userId to the order', () => {});
+    });
+  });
+});

--- a/server/app.js
+++ b/server/app.js
@@ -19,6 +19,7 @@ app.use('/api/auth', require('./api/auth'));
 app.use('/api/breeds', require('./api/breeds'));
 app.use('/api/dogs', require('./api/dogs'));
 app.use('/api/user', require('./api/user'));
+app.use('/api/orders', require('./api/orders'));
 
 app.use('/', express.static('dist'));
 app.get('/', (req, res, next) => res.sendFile(path.join(__dirname, '../client/index.html')));

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -5,11 +5,12 @@ const Breed = require('./models/Breed');
 const Dog = require('./models/Dog');
 const Order = require('./models/Order');
 const OrderItem = require('./models/OrderItem');
+const { createOrder } = require('./transactions/orderTransactions');
 
 Address.hasOne(User);
 Dog.belongsTo(Breed, { foreignKey: { allowNull: false } });
 Order.belongsTo(User);
-OrderItem.belongsTo(Order, { foreignKey: { allowNull: false } });
+Order.hasMany(OrderItem, { foreignKey: { allowNull: false } });
 OrderItem.belongsTo(Dog, { foreignKey: { allowNull: false } });
 
 const sync = async (force = false) => {
@@ -25,5 +26,8 @@ module.exports = {
     Dog,
     Order,
     OrderItem
+  },
+  transactions: {
+    createOrder
   }
 };

--- a/server/db/models/OrderItem.js
+++ b/server/db/models/OrderItem.js
@@ -1,10 +1,10 @@
 const connection = require('../connection');
 const { Sequelize } = connection;
-const { UUID, DECIMAL } = Sequelize;
+const { DECIMAL } = Sequelize;
 
 const { greaterThanZero } = require('./util/model_helper');
 
-const OrderItem = connection.define('order_item', {
+const OrderItem = connection.define('orderItem', {
   price: {
     type: DECIMAL,
     allowNull: false,

--- a/server/db/models/OrderItem.spec.js
+++ b/server/db/models/OrderItem.spec.js
@@ -39,7 +39,7 @@ describe('OrderItem Model', () => {
       delete orderItem.price;
 
       await expect(OrderItem.create(orderItem)).to.be.rejectedWith(
-        'notNull Violation: order_item.price cannot be null'
+        'notNull Violation: orderItem.price cannot be null'
       );
     });
 
@@ -58,7 +58,7 @@ describe('OrderItem Model', () => {
       orderItem.orderId = nonExistentOrderId;
 
       await expect(OrderItem.create(orderItem)).to.be.rejectedWith(
-        'insert or update on table "order_items" violates foreign key constraint "order_items_orderId_fkey"'
+        'insert or update on table "orderItems" violates foreign key constraint "orderItems_orderId_fkey"'
       );
     });
 
@@ -66,7 +66,7 @@ describe('OrderItem Model', () => {
       delete orderItem.orderId;
 
       await expect(OrderItem.create(orderItem)).to.be.rejectedWith(
-        'notNull Violation: order_item.orderId cannot be null'
+        'notNull Violation: orderItem.orderId cannot be null'
       );
     });
   });
@@ -77,7 +77,7 @@ describe('OrderItem Model', () => {
       orderItem.dogId = nonExistentDogId;
 
       await expect(OrderItem.create(orderItem)).to.be.rejectedWith(
-        'insert or update on table "order_items" violates foreign key constraint "order_items_dogId_fkey"'
+        'insert or update on table "orderItems" violates foreign key constraint "orderItems_dogId_fkey"'
       );
     });
 
@@ -85,7 +85,7 @@ describe('OrderItem Model', () => {
       delete orderItem.dogId;
 
       await expect(OrderItem.create(orderItem)).to.be.rejectedWith(
-        'notNull Violation: order_item.dogId cannot be null'
+        'notNull Violation: orderItem.dogId cannot be null'
       );
     });
   });

--- a/server/db/transactions/orderTransactions.js
+++ b/server/db/transactions/orderTransactions.js
@@ -1,0 +1,24 @@
+const connection = require('./../connection');
+const Dog = require('./../models/Dog');
+const Order = require('./../models/Order');
+const OrderItem = require('./../models/OrderItem');
+
+const createOrder = ({ order, crate }) =>
+  connection.transaction(async transaction => {
+    const createdOrder = await Order.create(order, { transaction });
+
+    for (let i = 0; i < crate.length; i++) {
+      const dog = await Dog.findByPk(crate[i]);
+      const orderItem = {
+        orderId: createdOrder.id,
+        dogId: dog.id,
+        price: dog.price
+      };
+      await OrderItem.create(orderItem, { transaction });
+      await dog.update({ isAvailable: false }, { transaction });
+    }
+
+    return createdOrder.id;
+  });
+
+module.exports = { createOrder };


### PR DESCRIPTION
This PR adds a POST /api/orders route that encapsulates the following in a transaction:
- create order
- create order items
- update dog to be unavailable